### PR TITLE
feat(backend_models): add MiniMax OpenAI-compatible backend

### DIFF
--- a/crab/agents/backend_models/__init__.py
+++ b/crab/agents/backend_models/__init__.py
@@ -21,11 +21,12 @@ from crab.core.backend_model import BackendModel
 from .camel_model import CamelModel
 from .claude_model import ClaudeModel
 from .gemini_model import GeminiModel
+from .minimax_model import MiniMaxModel
 from .openai_model import OpenAIModel, OpenAIModelJSON, SGlangOpenAIModelJSON
 
 
 class BackendModelConfig(BaseModel):
-    model_class: Literal["openai", "claude", "gemini", "camel", "sglang"]
+    model_class: Literal["openai", "claude", "gemini", "camel", "sglang", "minimax"]
     """Specify the model class to be used. Different model classese use different
     APIs.
     """
@@ -121,6 +122,19 @@ def create_backend_model(model_config: BackendModelConfig) -> BackendModel:
                 history_messages_len=model_config.history_messages_len,
                 base_url=model_config.base_url,
                 api_key=model_config.api_key,
+            )
+        case "minimax":
+            if model_config.json_structre_output:
+                raise Warning(
+                    "json_structre_output is not supported for MiniMaxModel currently."
+                )
+            return MiniMaxModel(
+                model=model_config.model_name,
+                parameters=model_config.parameters,
+                history_messages_len=model_config.history_messages_len,
+                base_url=model_config.base_url,
+                api_key=model_config.api_key,
+                tool_call_required=model_config.tool_call_required,
             )
         case "camel":
             return CamelModel(

--- a/crab/agents/backend_models/minimax_model.py
+++ b/crab/agents/backend_models/minimax_model.py
@@ -1,0 +1,51 @@
+# =========== Copyright 2024 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========== Copyright 2024 @ CAMEL-AI.org. All Rights Reserved. ===========
+from typing import Any
+
+from crab.agents.backend_models.openai_model import OpenAIModel
+
+# OpenAI-compatible base URLs for the available regions. The global endpoint is
+# used by default; set ``base_url`` explicitly to target another region.
+BASE_URLS: dict[str, str] = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh": "https://api.minimaxi.com/v1",
+}
+DEFAULT_BASE_URL = BASE_URLS["global_en"]
+
+
+class MiniMaxModel(OpenAIModel):
+    """Backend model served through an OpenAI-compatible API.
+
+    Reuses :class:`OpenAIModel` for the chat protocol and only supplies the
+    default base URL when ``base_url`` is not provided, so callers can point to
+    a regional endpoint via :attr:`BASE_URLS`.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        parameters: dict[str, Any] | None = None,
+        history_messages_len: int = 0,
+        tool_call_required: bool = True,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        super().__init__(
+            model=model,
+            parameters=parameters,
+            history_messages_len=history_messages_len,
+            tool_call_required=tool_call_required,
+            base_url=base_url or DEFAULT_BASE_URL,
+            api_key=api_key,
+        )

--- a/test/agents/backend_models/test_minimax_model.py
+++ b/test/agents/backend_models/test_minimax_model.py
@@ -1,0 +1,102 @@
+# =========== Copyright 2024 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========== Copyright 2024 @ CAMEL-AI.org. All Rights Reserved. ===========
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crab import action
+from crab.agents.backend_models import BackendModelConfig, create_backend_model
+from crab.agents.backend_models.minimax_model import (
+    BASE_URLS,
+    DEFAULT_BASE_URL,
+    MiniMaxModel,
+)
+from crab.agents.backend_models.openai_model import MessageType
+
+# Mock data for the OpenAI-compatible API response
+mock_response = MagicMock(
+    choices=[
+        MagicMock(
+            finish_reason="stop",
+            index=0,
+            logprobs=None,
+            message=MagicMock(
+                content="Hi there! How can I assist you today?",
+                role="assistant",
+                function_call=None,
+                tool_calls=None,
+            ),
+        )
+    ],
+    model="MiniMax-M3",
+    object="chat.completion",
+    usage=MagicMock(completion_tokens=10, prompt_tokens=19, total_tokens=29),
+)
+
+
+@pytest.fixture
+def minimax_model_text():
+    os.environ["OPENAI_API_KEY"] = "MOCK"
+    return create_backend_model(
+        BackendModelConfig(
+            model_class="minimax",
+            model_name="MiniMax-M3",
+            parameters={"max_tokens": 3000},
+            history_messages_len=1,
+            tool_call_required=False,
+        )
+    )
+
+
+@action
+def add(a: int, b: int):
+    """Add up two integers.
+
+    Args:
+        a: An addend
+        b: Another addend
+    """
+    return a + b
+
+
+def test_defaults_to_global_endpoint(minimax_model_text):
+    assert isinstance(minimax_model_text, MiniMaxModel)
+    assert DEFAULT_BASE_URL == BASE_URLS["global_en"]
+    assert str(minimax_model_text.client.base_url).startswith(DEFAULT_BASE_URL)
+
+
+def test_respects_regional_base_url():
+    os.environ["OPENAI_API_KEY"] = "MOCK"
+    model = create_backend_model(
+        BackendModelConfig(
+            model_class="minimax",
+            model_name="MiniMax-M2.7",
+            base_url=BASE_URLS["cn_zh"],
+        )
+    )
+    assert str(model.client.base_url).startswith(BASE_URLS["cn_zh"])
+
+
+@patch(
+    "openai.resources.chat.completions.Completions.create",
+    return_value=mock_response,
+)
+def test_text_chat(mock_create, minimax_model_text):
+    message = ("Hello!", MessageType.TEXT)
+    output = minimax_model_text.chat(message)
+    assert len(mock_create.call_args.kwargs["messages"]) == 2
+    assert output.message == "Hi there! How can I assist you today?"
+    assert output.action_list is None
+    assert minimax_model_text.token_usage == 29


### PR DESCRIPTION
Reason: BackendModelConfig had no MiniMax model class, so MiniMax-served models could not be selected through the standard configuration path.

## What changed
- Added a `MiniMaxModel` backend that reuses the existing OpenAI-compatible chat protocol and only supplies a default base URL, following the same subclassing pattern already used for the SGLang backend.
- Exposed the global and regional OpenAI-compatible base URLs as `BASE_URLS`, defaulting to the global endpoint while letting callers point to another region via `base_url`.
- Registered the new `"minimax"` value in `BackendModelConfig.model_class` and wired a matching branch in `create_backend_model`, honouring `base_url`, `api_key`, `parameters`, `history_messages_len`, and `tool_call_required`. JSON structured output is rejected with a clear warning, consistent with the other tool-calling backends.

## Tests
- `python3 -m pytest test/agents/backend_models/test_minimax_model.py` — covers the default endpoint, a regional `base_url` override, and a mocked text chat round-trip.
- `python3 -m pytest test/agents/backend_models/` — full backend-model suite still passes with no regressions.
- `ruff check` and `ruff format --check` on the touched files.
